### PR TITLE
Update gen.yaml to pin python-dateutils version

### DIFF
--- a/lending/gen.yaml
+++ b/lending/gen.yaml
@@ -14,7 +14,9 @@ python:
   version: 7.0.0
   additionalDependencies:
     dev: {}
-    main: {}
+    main: {
+      "python-dateutil": "2.9.0.post0"
+    }
   author: Codat
   authors:
     - Speakeasy


### PR DESCRIPTION
Update gen.yaml to pin python-dateutils version. This is currently causing a conflict for a clients of ours who is making heavy use of the lending lib. 