### PR TITLE
Issue deserialising `PushOperation` with `codatplatform` after creating supplier with `codat_lending`

### DIFF
--- a/platform/src/codatplatform/models/shared/pushoperation.py
+++ b/platform/src/codatplatform/models/shared/pushoperation.py
@@ -73,9 +73,9 @@ class PushOperation:
     r"""Available data types"""
     error_message: Optional[str] = dataclasses.field(default=UNSET, metadata={'dataclasses_json': { 'letter_case': utils.get_field_name('errorMessage'), 'exclude': lambda f: f is PushOperation.UNSET }})
     r"""A message about the error."""
-    timeout_in_minutes: Optional[int] = dataclasses.field(default=UNSET, metadata={'dataclasses_json': { 'letter_case': utils.get_field_name('timeoutInMinutes'), 'exclude': lambda f: f is PushOperation.UNSET }})
+    timeout_in_minutes: Optional[int] = dataclasses.field(default=None, metadata={'dataclasses_json': { 'letter_case': utils.get_field_name('timeoutInMinutes'), 'exclude': lambda f: f is PushOperation.UNSET }})
     r"""Number of minutes the push operation must complete within before it times out."""
-    timeout_in_seconds: Optional[int] = dataclasses.field(default=UNSET, metadata={'dataclasses_json': { 'letter_case': utils.get_field_name('timeoutInSeconds'), 'exclude': lambda f: f is PushOperation.UNSET }})
+    timeout_in_seconds: Optional[int] = dataclasses.field(default=None, metadata={'dataclasses_json': { 'letter_case': utils.get_field_name('timeoutInSeconds'), 'exclude': lambda f: f is PushOperation.UNSET }})
     r"""Number of seconds the push operation must complete within before it times out.
 
     Deprecated field: This will be removed in a future release, please migrate away from it as soon as possible.


### PR DESCRIPTION
⚠️ I know you're not supposed to edit this file manually, this is just to illustrate a fix and where the issue is

The basic issue is that I haven't been able to run [get push operation](https://docs.codat.io/platform-api#/operations/get-push-operation).

I could be using the SDK wrong, if so just let me know.

```txt
# requirements.txt
codat-lending==7.1.0
codat-platform==3.5.0
```

Say if I try to create a supplier and then run get push operation I get the following error
`ValueError: invalid literal for int() with base 10: '__SPEAKEASY_UNSET__'`

```py
# script.py
import os
import base64
import codat_lending
import codat_lending.codatlending_accounting_bank_data
from codat_lending.models import shared, operations
import codatplatform

codat_api_key = os.getenv("CODAT_API_KEY")

if codat_api_key is None:
    raise ValueError("CODAT_API_KEY environment variable is not set")

encoded_api_key = base64.b64encode(codat_api_key.encode()).decode()

lending_client = codat_lending.CodatLending(
    security=shared.Security(
        auth_header=f"Basic {encoded_api_key}",
    ),
)


COMPANY_ID = "" # TODO: Replace with your company ID
CONNECTION_ID = "" # TODO: Replace with your connection ID


request = operations.GetAccountingProfileRequest(
    company_id=COMPANY_ID,
)
response = lending_client.company_info.get_accounting_profile(request=request)

if response is None:
    raise ValueError("response is None")

supplier_create_request = operations.CreateSupplierRequest(
    accounting_supplier=shared.AccountingSupplier(
        addresses=[
            shared.AccountingAddress(
                line1="456 Oakwood Avenue",
                city="Manchester",
                country="UK",
                postal_code="M12 4LT",
                type=shared.AccountingAddressType.BILLING,
            ),
        ],
        default_currency="GBP",
        email_address="info@randomcompany.co.uk",
        registration_number="12345678",
        status=shared.SupplierStatus.ACTIVE,
        supplier_name="RANDOM COMPANY LTD",
    ),
    company_id=COMPANY_ID,
    connection_id=CONNECTION_ID,
)

supplier_create_response = lending_client.loan_writeback.suppliers.create(
    request=supplier_create_request
)

if supplier_create_response is None:
    raise ValueError("supplier_create_response is None")


platform_client = codatplatform.CodatPlatform(
    security=codatplatform.settings.shared.Security(
        auth_header=f"Basic {encoded_api_key}",
    ),
)

push_operation_request = (
    codatplatform.push_data.operations.get_push_operation.GetPushOperationRequest(
        company_id=COMPANY_ID,
        push_operation_key=supplier_create_response.push_operation_key,
    )
)

push_operation_response = platform_client.push_data.get_operation(
    request=push_operation_request
)
```

I've tried looking into the code and I've noticed that it doesn't work if I use the `PushOperation` from `codat_lending`.

```py
# issue.py

import codat_lending
import codatplatform

# Note: The UUIDs have been randomised
http_res_text = '{"changes":[{"type":"Created","recordRef":{"id":"3f9e8a7c-12b4-4a67-b918-67389f2f3b75","dataType":"suppliers"}}],"dataType":"suppliers","companyId":"1bfc7e02-d5aa-4032-94b9-01f2a15bb635","pushOperationKey":"4e50899f-41f2-4f9b-bc57-5dbd26c2f633","dataConnectionKey":"d25b7c4e-8214-4e12-a306-e5f5d2c6f1c9","requestedOnUtc":"2024-10-17T15:44:38.9481460Z","completedOnUtc":"2024-10-17T15:44:39.0652450Z","status":"Success","statusCode":200}'

codat_lending_out = codat_lending.utils.unmarshal_json(http_res_text, codat_lending.Optional[codat_lending.shared.PushOperation])
# codat_lending.shared.PushOperation works fine ✅ 
print(codat_lending_out)

codatplatform_out = codatplatform.utils.unmarshal_json(http_res_text, codatplatform.Optional[codatplatform.shared.PushOperation])
# codatplatform.shared.PushOperation raises ValueError: invalid literal for int() with base 10: '__SPEAKEASY_UNSET__' ❌
print(codatplatform_out)
```

Link to the working model is https://github.com/codatio/client-sdk-python/blob/main/lending/src/codat_lending/models/shared/pushoperation.py