### PR TITLE
Bank feed mapping type issue

### DIFF
--- a/bank-feeds/src/codat_bankfeeds/models/shared/bankfeedmapping.py
+++ b/bank-feeds/src/codat_bankfeeds/models/shared/bankfeedmapping.py
@@ -108,7 +108,7 @@ class BankFeedMapping(BaseModel):
     ] = None
     r"""Account number for the source account."""
 
-    source_balance: Annotated[Optional[str], pydantic.Field(alias="sourceBalance")] = (
+    source_balance: Annotated[Optional[int], pydantic.Field(alias="sourceBalance")] = (
         None
     )
     r"""Balance for the source account."""


### PR DESCRIPTION
I don't expect you to merge this PR, I guess there's either a data issue or something wrong with the OpenAPI spec or Speakeasy ... However, I'm using this PR to demonstrate this issue.

When calling this endpoint https://docs.codat.io/bank-feeds-api#/operations/get-bank-account-mapping
```py
import os
import codat_bankfeeds
import base64

COMPANY_ID = "insert-company-id"
CONNECTION_ID = "insert-connection-id"

codat_api_key = os.environ.get("CODAT_API_KEY")
if codat_api_key is None:
    raise ValueError("CODAT_API_KEY environment variable is not set")
encoded_api_key = base64.b64encode(codat_api_key.encode()).decode()


bankfeeds_client = codat_bankfeeds.CodatBankFeeds(
    security=codat_bankfeeds.shared.Security(
        auth_header=f"Basic {encoded_api_key}",
    ),
)

bank_feed_accounts = bankfeeds_client.account_mapping.get(
    request={
        "company_id": COMPANY_ID,
        "connection_id": CONNECTION_ID,
    }
)

```

Pydantic gets upset because the `sourceBalance` is not a `str`.

```
ValidationError: 1 validation error for Unmarshaller
body.0.sourceBalance
  Input should be a valid string [type=string_type, input_value=0.0, input_type=float]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
```

If I edit the type to `int` as per this PR then it works.

Here's an example of the JSON returned from the API when calling via CURL or Postman etc. Notice that `sourceBalance` is `0` and not a string

```json
[
  {
    "sourceAccountId": "acc-567",
    "targetAccountId": "d129850c-af5c-4e0c-90a9-9b3f3eb2d5b4",
    "feedStartDate": "2024-11-15T11:42:16.0000000",
    "status": "connected",
    "targetAccountOptions": [
      {
        "name": "Seller Bank Account",
        "id": "4ad73daa-8b4d-4d84-9a5e-ad1a2d4f3f7f",
        "accountNumber": "56",
        "bankCode": "987654"
      },
      {
        "name": "Lender Bank Account",
        "id": "56bbed02-93c5-4769-8c6f-5af8ed7b98c7",
        "accountNumber": "98765432",
        "bankCode": "765432"
      }
    ],
    "sourceAccountName": "account-123",
    "sourceAccountNumber": "11111111",
    "sourceBalance": 0,
    "sourceCurrency": "GBP",
    "targetAccountName": "Lender Bank Account",
    "targetAccountNumber": "98765432"
  }
]
```