### PR TITLE
Update speakeasyVersion to 1.715.0

### DIFF
--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,6 +1,4 @@
 speakeasyVersion: 1.715.0
-speakeasyVersion: 1.709.1
-speakeasyVersion: 1.701.0
 sources:
     accounting-source:
         sourceNamespace: accounting-source


### PR DESCRIPTION
Fixing errors in workflow.lock created by poor merge conflict hygiene